### PR TITLE
feat: implement create roles action (#27)

### DIFF
--- a/src/components/Forms/NewRoleForm/NewRoleForm.jsx
+++ b/src/components/Forms/NewRoleForm/NewRoleForm.jsx
@@ -1,0 +1,99 @@
+import styles from "./NewRoleForm.module.css";
+import { useState } from "react";
+import { useNavigate } from "react-router-dom";
+import { db } from "../../../firebase";
+import { collection, doc, serverTimestamp, setDoc } from "firebase/firestore";
+import Swal from "sweetalert2";
+import { useGoogleAuth } from "../../../context/GoogleAuthContext";
+
+const NewRoleForm = ({ formTitle, setOpen }) => {
+    const { googleUser } = useGoogleAuth();
+
+    // useState hook for onChange event in the input elements
+    const [values, setValues] = useState({ role: "" });
+
+    //Hook for display error message (validation) just when input is not focused
+    const [notFocused, setNotFocused] = useState(false);
+
+    const navigate = useNavigate();
+
+    const handleNotFocused = (e) => {
+        setNotFocused(true); // Set not focused to true when input is not in focus
+    };
+
+    const onChange = (e) => {
+        /*
+         *   Spread the values, that means take all the current values
+         *   and add/change only the one we are handling in this onChange function
+         */
+        setValues({ ...values, [e.target.name]: e.target.value });
+    };
+
+    const handleSubmit = async (e) => {
+        e.preventDefault(); //prevent page refresh when submitting the form
+        setOpen(false); //close modal after submiting the form
+        try {
+            Swal.fire({
+                title: "Registrando rol",
+                didOpen: () => {
+                    Swal.showLoading();
+                },
+            });
+            // upload values to Firestore
+            await setDoc(doc(collection(db, "roles")), {
+                ...values,
+                createdBy: googleUser.displayName,
+                timeStamp: serverTimestamp(),
+            });
+            Swal.fire({
+                icon: "success",
+                title: "Nuevo rol registrado",
+                showConfirmButton: false,
+                timer: 1500,
+            }).then(() => {
+                navigate(0);
+            });
+        } catch (error) {
+            // show an error message if something went wrong
+            Swal.fire({
+                icon: "error",
+                title: "Error",
+                text: error.message,
+                showConfirmButton: true,
+            }).then(() => {
+                navigate(0);
+            });
+        }
+    };
+    console.log(values);
+
+    return (
+        <form onSubmit={handleSubmit}>
+            <h2 className={styles.formTitle}>{formTitle}</h2>
+            <div className={styles.formInput}>
+                <label className={styles.labelGeneric}>Rol</label>
+                <input
+                    required
+                    name="role"
+                    type="text"
+                    pattern="^[A-Za-zÀÁÉÍÓÚñü s]+$"
+                    className={styles.inputGeneric}
+                    onChange={onChange}
+                    onBlur={handleNotFocused}
+                    focused={notFocused.toString()}
+                />
+                <span className={styles.particularErrorMessage}>
+                    "¡Por favor, no debe estar vacío y/o no debe contener
+                    caracteres especiales y números!",
+                </span>
+            </div>
+            <div className={styles.buttonContainer}>
+                <button type="submit" className={styles.submitButton}>
+                    Enviar
+                </button>
+            </div>
+        </form>
+    );
+};
+
+export default NewRoleForm;

--- a/src/components/Forms/NewRoleForm/NewRoleForm.module.css
+++ b/src/components/Forms/NewRoleForm/NewRoleForm.module.css
@@ -1,0 +1,55 @@
+.formTitle {
+    color: var(--main-color);
+    /* text-align: center; */
+    margin-bottom: 30px;
+}
+
+.buttonContainer {
+    width: 100%;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+}
+
+.submitButton {
+    color: white;
+    font-weight: bold;
+    padding: 10px;
+    border-radius: 10px;
+    width: 100%; /*Same as default Google Button width*/
+    text-transform: uppercase;
+    cursor: pointer;
+    margin: 30px 0;
+}
+
+.formInput {
+    width: 100%;
+    margin: 0;
+    display: flex;
+    flex-direction: column;
+    justify-content: left;
+    align-items: start;
+}
+
+.inputGeneric {
+    padding: 15px;
+    border-radius: 5px;
+    border: 1px solid var(--border-color);
+    width: 97%;
+}
+
+.particularErrorMessage {
+    font-size: 12px;
+    color: red;
+    display: none;
+}
+
+/* When there´s an error and the input is not focused, put a border to the input*/
+input:invalid[focused="true"] {
+    border: 1px solid red;
+}
+
+/* When the input is invalid, show the error message */
+input:invalid[focused="true"] ~ .particularErrorMessage {
+    display: block;
+}

--- a/src/components/Forms/NewUserForm/SelectInput.jsx
+++ b/src/components/Forms/NewUserForm/SelectInput.jsx
@@ -16,11 +16,32 @@ const SelectInput = (props) => {
                 <option hidden value="">
                     Seleccione una opción
                 </option>
-                {options.map((option, index) => (
-                    <option key={index} value={option}>
-                        {option}
-                    </option>
-                ))}
+                {name === "idDocumentType" ? (
+                    <>
+                        <option value="C.C.">C.C.</option>
+                        {options.map((option, index) => (
+                            <option key={index} value={option}>
+                                {option}
+                            </option>
+                        ))}
+                    </>
+                ) : name === "role" ? (
+                    <>
+                        <option value="Usuario">Usuario</option>
+                        <option value="Moderador">Moderador</option>
+                        {options.map((option, index) => (
+                            <option key={index} value={option}>
+                                {option}
+                            </option>
+                        ))}
+                    </>
+                ) : (
+                    options.map((option, index) => (
+                        <option key={index} value={option}>
+                            {option}
+                        </option>
+                    ))
+                )}
             </select>
         </div>
     );

--- a/src/components/GoogleAuth/GoogleAuth.jsx
+++ b/src/components/GoogleAuth/GoogleAuth.jsx
@@ -14,7 +14,7 @@ const GoogleAuth = () => {
         if (googleUser) {
             navigate("/");
         }
-    }, [googleUser]); //googleUser and navigate state changing are dependencies of the effect hook
+    }, [googleUser, navigate]); //googleUser and navigate state changing are dependencies of the effect hook
 
     return (
         <>

--- a/src/context/GoogleAuthContext.js
+++ b/src/context/GoogleAuthContext.js
@@ -22,12 +22,11 @@ export const GoogleAuthContextProvider = ({ children }) => {
             // Create a Google provider
             const provider = new GoogleAuthProvider();
             // Sign in with Google and wait for the response
-            const result = await signInWithPopup(auth, provider);
-            // Set the user state props and spread with the authentication result
-            setGoogleUser(result.googleUser);
+            await signInWithPopup(auth, provider);
             setIsLoggedInWithGoogle(true);
         } catch (error) {
             console.log("Error signing in with Google", error);
+            setIsLoggedInWithGoogle(false);
         }
     };
 
@@ -49,7 +48,6 @@ export const GoogleAuthContextProvider = ({ children }) => {
         // Create a function to listen for changes in the authentication state
         const unsubscribe = onAuthStateChanged(auth, (currentUser) => {
             setGoogleUser(currentUser);
-            setIsLoggedInWithGoogle(true);
         });
         // Return a function to unsubscribe when the component is unmounted
         return () => {

--- a/src/context/ProtectedWithGoogleAuth.js
+++ b/src/context/ProtectedWithGoogleAuth.js
@@ -1,12 +1,13 @@
 import { Navigate } from "react-router-dom";
 import { useGoogleAuth } from "./GoogleAuthContext";
 
-const Protected = ({ children }) => {
+const ProtectedWithGoogleAuth = ({ children }) => {
     const { googleUser } = useGoogleAuth();
 
-    if (!googleUser) return <Navigate to="/login" />; // If user is not logged in, redirect them to the login page.
+    // Implement an emailAndPassword condition for returning children components
 
-    return children; // Otherwise, show the protected content
+    if (googleUser) return children; // If user is logged in, show the protected content
+    return <Navigate to="/login" />; // Otherwise, redirect them to the login page
 };
 
-export default Protected;
+export default ProtectedWithGoogleAuth;

--- a/src/routes/IDTypesManagement/IDTypesManagement.jsx
+++ b/src/routes/IDTypesManagement/IDTypesManagement.jsx
@@ -24,7 +24,7 @@ const DocumentTypesManagement = () => {
                     </div>
                     <Table
                         tableBasicColumns={usersColumns}
-                        tableType={"roles"}
+                        tableType={"idDocuments"}
                         UpdateForm={UpdateUserForm}
                     />
                 </div>

--- a/src/routes/RolesManagement/RolesManagement.jsx
+++ b/src/routes/RolesManagement/RolesManagement.jsx
@@ -3,9 +3,10 @@ import HeaderForGoogleUsers from "../../components/Header/HeaderForGoogleUsers";
 import CreateActionButtonAndModal from "../../components/ActionButtons/CreateActionButtonAndModal";
 import AdminPanelSettingsIcon from "@mui/icons-material/AdminPanelSettings";
 import Table from "../../components/Tables/Table";
-import { usersColumns } from "../../utils/tableBasicColumns";
+import { rolesColumns } from "../../utils/tableBasicColumns";
 import UpdateUserForm from "../../components/Forms/UpdateUserForm/UpdateUserForm";
 import NewUserForm from "../../components/Forms/NewUserForm/NewUserForm";
+import NewRoleForm from "../../components/Forms/NewRoleForm/NewRoleForm";
 
 const RolesManagement = () => {
     return (
@@ -19,11 +20,11 @@ const RolesManagement = () => {
                             IconForButton={<AdminPanelSettingsIcon />}
                             textForButton={"Nuevo rol"}
                             formTitle={"Crear nuevo rol"}
-                            ModalContent={NewUserForm}
+                            ModalContent={NewRoleForm}
                         />
                     </div>
                     <Table
-                        tableBasicColumns={usersColumns}
+                        tableBasicColumns={rolesColumns}
                         tableType={"roles"}
                         UpdateForm={UpdateUserForm}
                     />

--- a/src/utils/registerInputsData.js
+++ b/src/utils/registerInputsData.js
@@ -116,11 +116,11 @@ export const selectsData = [
     {
         id: 2,
         name: "idDocumentType",
-        options: ["C.C.", "C.E.", "T.I.", "P.B.", "R.C."],
+        options: [],
     },
     {
         id: 3,
         name: "role",
-        options: ["Usuario", "Moderador"],
+        options: [],
     },
 ];

--- a/src/utils/tableBasicColumns.js
+++ b/src/utils/tableBasicColumns.js
@@ -34,3 +34,12 @@ export const usersColumns = [
     { field: "email", headerName: "Correo electrónico", flex: 1 },
     { field: "phoneNumber", headerName: "Celular", flex: 1 },
 ];
+
+export const rolesColumns = [
+    { field: "id", headerName: "ID", flex: 1 },
+    {
+        field: "role",
+        headerName: "Rol",
+        flex: 1,
+    },
+];


### PR DESCRIPTION
* update RolesManagement.jsx and tableBasicColumns.js to use rolesColumns instead of usersColumns

* add NewRoleForm component to RolesManagement page

* update NewRoleForm to restrict role input to letters and set role document id

* Add pattern to role input to restrict it to letters only
* Set role document id as the value of the role input
* Log the values being submitted in

* replace doc reference with collection reference in setDoc for Firestore

* add googleUser to NewRoleForm, update SelectInput and IDTypesManagement, and empty options for idDocumentType and role in registerInputsData

* update GoogleAuth and related components to include 'navigate' in dependencies and remove unnecessary state assignment in GoogleAuthContext

* feat complete